### PR TITLE
Additional support for <note> and <changelog>

### DIFF
--- a/src/main/resources/ro/kuberam/maven/plugins/expath/generate-descriptors.xsl
+++ b/src/main/resources/ro/kuberam/maven/plugins/expath/generate-descriptors.xsl
@@ -146,7 +146,17 @@
 					<permissions user="{$permissions/@user}" password="{$permissions/@password}"
 						group="{$permissions/@group}" mode="{$permissions/@mode}" />
 				</xsl:if>
-				<xsl:if test="/*/pkg:deployed">
+				<xsl:if test="/*/pkg:note">
+                    <note>
+                        <xsl:value-of select="/*/pkg:note" />
+                    </note>
+                </xsl:if>
+                <xsl:if test="/*/pkg:changelog">
+                    <changelog>
+                        <xsl:copy-of select="/*/pkg:changelog/node()"/>
+                    </changelog>
+                </xsl:if>
+                <xsl:if test="/*/pkg:deployed">
 					<deployed>
 						<xsl:value-of select="/*/pkg:deployed" />
 					</deployed>


### PR DESCRIPTION
Fixes #6 

example output

```xml
<?xml version="1.0" encoding="UTF-8"?>
<meta xmlns="http://exist-db.org/xquery/repo"
      xmlns:repo="http://exist-db.org/xquery/repo"
      xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <description>${package-title}</description>
   <author id="my-organisation">My Organisation</author>
   <website>${project.url}</website>
   <status>stable</status>
   <license>GNU Lesser General Public License, version 2.1</license>
   <copyright>true</copyright>
   <type>application</type>
   <target>${package-abbrev}</target>
   <prepare>pre-install.xq</prepare>
   <finish>post-install.xq</finish>
   <permissions user="app-user"
                password="123"
                group="app-group"
                mode="rw-rw-r--"/>
   <note>When upgrading: please first uninstall all previous versions and restart eXist-db.</note>
   <changelog>
        <change xmlns="http://expath.org/ns/pkg" version="0.5.5">
            <ul xmlns="http://www.w3.org/1999/xhtml">
                <li>Another improvement on JSON conversion: Support of more datatypes.</li>
            </ul>
        </change>
        <change xmlns="http://expath.org/ns/pkg" version="0.5.4">
            <ul xmlns="http://www.w3.org/1999/xhtml">
                <li>Improved conversion of XQuery-JSON objects to Couchbase-JSON objects and vice versa.</li>
                <li>Upgrade to Java driver version v2.4.3.</li>
            </ul>
        </change>
    </changelog>
</meta>
```
  